### PR TITLE
Catch "closed network" error with `errors.Is`

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ For usage on Kubernetes, see: [artifacts](/artifacts)
 ### Local
 
 ```bash
-go build && ./inlets-connect --upstream 192.168.0.15:443 --port 3128
+go build && ./inlets-connect -upstream 192.168.0.15:443 -port 3128
 
 curl https://192.168.0.15 -x http://127.0.0.1:3128
 ```

--- a/main.go
+++ b/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"flag"
 	"fmt"
 	"io"
@@ -8,7 +9,6 @@ import (
 	"net"
 	"net/http"
 	"os"
-	"strings"
 	"time"
 
 	"golang.org/x/sync/errgroup"
@@ -92,7 +92,7 @@ func pipe(from net.Conn, to net.Conn) error {
 	defer from.Close()
 	n, err := io.Copy(from, to)
 	log.Printf("Wrote: %d bytes", n)
-	if err != nil && strings.Contains(err.Error(), "closed network") {
+	if errors.Is(err, net.ErrClosed) {
 		return nil
 	}
 	return err


### PR DESCRIPTION
- Replaces checking error body with `errors.Is` to handle the case when connection is closed.
- Fixes a small typo in docs.
